### PR TITLE
Fix commands refusing to work unless in toplevel

### DIFF
--- a/git-next
+++ b/git-next
@@ -2,6 +2,7 @@
 
 set -e
 
+SUBDIRECTORY_OK=1
 source "$(git --exec-path)/git-sh-setup"
 
 # Generate a portable in-place sed "variable".

--- a/git-prev
+++ b/git-prev
@@ -2,6 +2,7 @@
 
 set -e
 
+SUBDIRECTORY_OK=1
 source "$(git --exec-path)/git-sh-setup"
 
 # Generate a portable in-place sed "variable".


### PR DESCRIPTION
These commands are clearly intended to support being called from
within subdirectories of a git repository, as shown by the use of
`cd_to_toplevel`. However, the git-sh-setup script refuses to allow this
by default, unless told otherwise by the `SUBDIRECTORY_OK` variable.