### PR TITLE
Fix git-next to work in the face of rebases with -x/--exec

### DIFF
--- a/git-next
+++ b/git-next
@@ -40,12 +40,8 @@ for ((iter=0;iter<${1:-1};iter++)); do
         exit
     fi
 
-    # Ensure the next commit is an edit.
-    # If this fails, print the result.
-    if ! errtext=$(GIT_SEQUENCE_EDITOR="$IN_PLACE_SED '1 s/^[a-z]\{1,\}/edit/'" git rebase --edit-todo 2>&1); then
-        echo "$errtext" 1>&2
-        die
-    fi
+    # Make the next 'pick' an 'edit'.
+    GIT_SEQUENCE_EDITOR="$IN_PLACE_SED -e '/^pick/{s//edit/;:a' -e '$!N;$!ba' -e '}'" git rebase --edit-todo
 
     # Go to next commit.
     if ! errtext=$(git rebase --continue 2>&1); then


### PR DESCRIPTION
When attempting to use git-next when an "actual" rebase is in progress
and said rebase uses additional execute actions (-x/--exec), the program
will just fail, because the next line in the rebase todo log will
effectively be transformed into garbage by the sed command.

```
$ git rebase -i HEAD~4 -x 'echo foobar'
$ git next
> error: could not parse 'echo'
> error: invalid line 1: edit echo foobar
> You can fix this with 'git rebase --edit-todo' and then run 'git rebase --continue'.
> Or you can abort the rebase with 'git rebase --abort'.
$ cat .git/rebase-merge/git-rebase-todo
> edit echo foobar
> ...
```
This change replaces the sed command used by git-next with one that
replaces the *first* 'pick' found at the beginning of a line with an
'edit'. This is much more flexible than the previous approach of
unconditionally working on the first line. It also means (as per my
understanding) that we effectively eliminate the error condition that we
had to check for previously.
The proposed magic string is coming from linuxtopia [0] and intended to
work on all versions of sed, not just GNU sed (also see stackoverflow
for a discussion [1]). I have not tested that myself.

[0] https://www.linuxtopia.org/online_books/linux_tool_guides/the_sed_faq/sedfaq4_004.html
[1] https://stackoverflow.com/questions/148451/how-to-use-sed-to-replace-only-the-first-occurrence-in-a-file#11458836